### PR TITLE
Fix bamboo build number being empty

### DIFF
--- a/src/main/java/pl/project13/core/cibuild/BambooBuildServerData.java
+++ b/src/main/java/pl/project13/core/cibuild/BambooBuildServerData.java
@@ -43,7 +43,8 @@ public class BambooBuildServerData extends BuildServerDataProvider {
   @Override
   void loadBuildNumber(@Nonnull Properties properties) {
     String buildNumber = Optional.ofNullable(env.get("bamboo.buildNumber"))
-            .orElseGet(() -> env.getOrDefault("BAMBOO_BUILDNUMBER", ""));
+            .or(() -> Optional.ofNullable(env.get("BAMBOO_BUILDNUMBER")))
+            .orElseGet(() -> env.getOrDefault("bamboo_buildNumber", ""));
 
     maybePut(properties, GitCommitPropertyConstant.BUILD_NUMBER, () -> buildNumber);
   }


### PR DESCRIPTION
Hi there,
I noticed, that the field `git.build.number` was empty on our Bamboo (v7.2.3). After a bit of digging, I found that it has to do with the environment variables which the plugin is reading. It's reading `bamboo.buildNumber` and `BAMBOO_BUILDNUMBER`, however bamboo is only setting `bamboo_buildNumber`.
In the documentation (https://confluence.atlassian.com/bamboo/bamboo-variables-289277087.html#Bamboovariables-Systemvariables) under "System variables" it is explained that "Bamboo Variables" are converted to shell variables by converting any dot to an underscore. My understanding is that Bamboo Variables like "bamboo.buildNumber" are only substituted when used in a command or script task in Bamboo.

### Contributor Checklist
- [ ] Added relevant integration or unit tests to verify the changes
- [ ] Update the Readme or any other documentation (including relevant Javadoc)
- [x] Ensured that tests pass locally: `mvn clean package`
- [x] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
