### PR TITLE
#3: Remove org.sonatype.plexus dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,12 +185,6 @@
             <artifactId>joda-time</artifactId>
             <version>2.10.10</version>
         </dependency>
-        <!-- plexus build -->
-        <dependency>
-            <groupId>org.sonatype.plexus</groupId>
-            <artifactId>plexus-build-api</artifactId>
-            <version>0.0.7</version>
-        </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
@@ -217,18 +211,6 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-utils</artifactId>
-            <version>3.3.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-container-default</artifactId>
-            <version>2.1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/pl/project13/core/PropertiesFileGenerator.java
+++ b/src/main/java/pl/project13/core/PropertiesFileGenerator.java
@@ -18,8 +18,8 @@
 package pl.project13.core;
 
 import nu.studer.java.util.OrderedProperties;
-import org.sonatype.plexus.build.incremental.BuildContext;
 import pl.project13.core.log.LoggerBridge;
+import pl.project13.core.util.BuildFileChangeListener;
 import pl.project13.core.util.JsonManager;
 import pl.project13.core.util.PropertyManager;
 
@@ -33,14 +33,14 @@ import java.util.Properties;
 public class PropertiesFileGenerator {
 
   private LoggerBridge log;
-  private BuildContext buildContext;
+  private BuildFileChangeListener buildFileChangeListener;
   private String format;
   private String prefixDot;
   private String projectName;
 
-  public PropertiesFileGenerator(LoggerBridge log, BuildContext buildContext, String format, String prefixDot, String projectName) {
+  public PropertiesFileGenerator(LoggerBridge log, BuildFileChangeListener buildFileChangeListener, String format, String prefixDot, String projectName) {
     this.log = log;
-    this.buildContext = buildContext;
+    this.buildFileChangeListener = buildFileChangeListener;
     this.format = format;
     this.prefixDot = prefixDot;
     this.projectName = projectName;
@@ -97,8 +97,8 @@ public class PropertiesFileGenerator {
           throw new RuntimeException("Cannot create custom git properties file: " + gitPropsFile, ex);
         }
 
-        if (buildContext != null) {
-          buildContext.refresh(gitPropsFile);
+        if (buildFileChangeListener != null) {
+          buildFileChangeListener.changed(gitPropsFile);
         }
 
       } else {

--- a/src/main/java/pl/project13/core/util/BuildFileChangeListener.java
+++ b/src/main/java/pl/project13/core/util/BuildFileChangeListener.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of git-commit-id-plugin-core by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ *
+ * git-commit-id-plugin-core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * git-commit-id-plugin-core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with git-commit-id-plugin-core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pl.project13.core.util;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.util.EventListener;
+
+public interface BuildFileChangeListener extends EventListener {
+  /**
+   * Event will be fired when then {@link pl.project13.core.PropertiesFileGenerator} changed the output file.
+   * A client who may want to implement that listener may want to perform other actions.
+   * E.g.
+   * {code}
+   * BuildContext buildContext = ...
+   * new BuildFileChangeListener() {
+   *   void changed(@Nonnull File file) {
+   *     buildContext.refresh(file);
+   *   }
+   * }
+   * {code}
+   * @param file The output properties File that was changed by the generator
+   */
+  void changed(@Nonnull File file);
+}

--- a/src/test/java/pl/project13/core/PropertiesFileGeneratorTest.java
+++ b/src/test/java/pl/project13/core/PropertiesFileGeneratorTest.java
@@ -21,10 +21,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.sonatype.plexus.build.incremental.BuildContext;
-import org.sonatype.plexus.build.incremental.DefaultBuildContext;
 import pl.project13.core.log.LoggerBridge;
 import pl.project13.core.log.StdOutLoggerBridge;
+import pl.project13.core.util.BuildFileChangeListener;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -39,13 +38,16 @@ public class PropertiesFileGeneratorTest {
   public final TemporaryFolder temporaryFolder = new TemporaryFolder();
   
   private final LoggerBridge loggerBridge = new StdOutLoggerBridge(false);
-  private final BuildContext buildContext = new DefaultBuildContext();
   
   private PropertiesFileGenerator propertiesFileGenerator;
   
   @Before
   public void setUp() {
-    propertiesFileGenerator = new PropertiesFileGenerator(loggerBridge, buildContext, "properties", "", "test");
+    BuildFileChangeListener buildFileChangeListener = file -> {
+      // Ignore
+    };
+
+    propertiesFileGenerator = new PropertiesFileGenerator(loggerBridge, buildFileChangeListener, "properties", "", "test");
   }
   
   @Test


### PR DESCRIPTION
Closes https://github.com/git-commit-id/git-commit-id-plugin-core/issues/3: Remove org.sonatype.plexus dependency

### Context
<!--- Thank you for your contribution to this project! :-) -->
<!--- Please tell us a bit more what do you indent with your change and how users of the plugin will benefit from it. -->
<!--- If applicable also provide a link to any relevant issue. -->

### Contributor Checklist
- [ ] Added relevant integration or unit tests to verify the changes
- [ ] Update the Readme or any other documentation (including relevant Javadoc)
- [ ] Ensured that tests pass locally: `mvn clean package`
- [ ] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
