### PR TITLE
get file store attr async to improve jgit startup performance

### DIFF
--- a/src/main/java/pl/project13/core/JGitProvider.java
+++ b/src/main/java/pl/project13/core/JGitProvider.java
@@ -25,6 +25,7 @@ import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.revwalk.RevWalkUtils;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.eclipse.jgit.util.FS;
 
 import pl.project13.core.jgit.DescribeResult;
 import pl.project13.core.jgit.JGitCommon;
@@ -58,6 +59,7 @@ public class JGitProvider extends GitDataProvider {
   JGitProvider(@Nonnull File dotGitDirectory, @Nonnull LogInterface log) {
     super(log);
     this.dotGitDirectory = dotGitDirectory;
+    FS.FileStoreAttributes.setBackground(true);
     this.jGitCommon = new JGitCommon(log);
   }
 


### PR DESCRIPTION
Let jgit calculate the file store attr async. In container environment, especially when .git dir and ~/.config/jgit locate on different volumes, jgit have to wait 3 seconds to fetch the file store attr before collect git repo info, and another 3 seconds in saver thread to write the attr into ~/.config/jgit.

In sync way, when we execute some short maven goals, such as `mvn validate`, the total time is less than 6 seconds, then maven exits with a dirty state in ~/.config/jgit, the `config.lock` and `.probe-<UUID>` file left there. After that the jgit will always fail to read or write to the default config file. With this pr, we can almost avoid this dirty state.

A releated jgit issue is here https://bugs.eclipse.org/bugs/show_bug.cgi?id=579445

### Context
<!--- Thank you for your contribution to this project! :-) -->
<!--- Please tell us a bit more what do you indent with your change and how users of the plugin will benefit from it. -->
<!--- If applicable also provide a link to any relevant issue. -->

### Contributor Checklist
- [ ] Added relevant integration or unit tests to verify the changes
- [ ] Update the Readme or any other documentation (including relevant Javadoc)
- [x] Ensured that tests pass locally: `mvn clean package`
- [x] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
