### PR TITLE
#57: Use relocated json dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,14 +196,14 @@
         </dependency>
         <!-- json stuff -->
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
-            <version>1.1.4</version>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <version>2.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
-            <version>1.1.4</version>
+            <artifactId>jakarta.json</artifactId>
+            <version>2.0.1</version>
         </dependency>
         <!-- yaml -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -201,9 +201,9 @@
             <version>2.1.2</version>
         </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.json</artifactId>
-            <version>2.0.1</version>
+            <groupId>org.eclipse.parsson</groupId>
+            <artifactId>parsson</artifactId>
+            <version>1.1.4</version>
         </dependency>
         <!-- yaml -->
         <dependency>

--- a/src/main/java/pl/project13/core/util/JsonManager.java
+++ b/src/main/java/pl/project13/core/util/JsonManager.java
@@ -17,15 +17,15 @@
 
 package pl.project13.core.util;
 
+import jakarta.json.Json;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonString;
+import jakarta.json.stream.JsonGenerator;
+import jakarta.json.stream.JsonGeneratorFactory;
 import nu.studer.java.util.OrderedProperties;
 import pl.project13.core.CannotReadFileException;
 
 import javax.annotation.Nonnull;
-import javax.json.Json;
-import javax.json.JsonReader;
-import javax.json.JsonString;
-import javax.json.stream.JsonGenerator;
-import javax.json.stream.JsonGeneratorFactory;
 import java.io.*;
 import java.nio.charset.Charset;
 import java.util.Collections;

--- a/src/test/java/pl/project13/core/util/TestJsonManager.java
+++ b/src/test/java/pl/project13/core/util/TestJsonManager.java
@@ -52,7 +52,6 @@ public class TestJsonManager {
     // then
     Assert.assertEquals(
             Arrays.asList(
-                    "",
                     "{",
                     "    \"git.commit.id\": \"beef4e92e9cabd043b105a14514289f331b40bf2\",",
                     "    \"git.commit.id.abbrev\": \"beef4e9\"",
@@ -101,7 +100,6 @@ public class TestJsonManager {
     // then
     Assert.assertEquals(
             Arrays.asList(
-                    "",
                     "{",
                     "    \"git.commit.id.abbrev\": \"beef4e9\",",
                     "    \"git.commit.id.full\": \"beef4e92e9cabd043b105a14514289f331b40bf2\"",
@@ -150,7 +148,6 @@ public class TestJsonManager {
     // then
     Assert.assertEquals(
             Arrays.asList(
-                    "",
                     "{",
                     "    \"git.commit.message.full\": \"initial commit on test project with some special characters äöüàñ.\",",
                     "    \"git.commit.user.name\": \"Александр Eliáš\"",


### PR DESCRIPTION
Fix #57: Use relocated json dependencies

- The dependency javax.json:javax.json-api was relocated to jakarta.json:jakarta.json-api (implicit bump from version 1.1.4 to 2.1.2)
- The dependency org.glassfish:javax.json was relocated to org.glassfish:jakarta.json (implicit bump from version 1.1.4 to 2.0.1)
