### PR TITLE
add git.tag to get the tag on a certain commit

### DIFF
--- a/src/main/java/pl/project13/core/GitCommitPropertyConstant.java
+++ b/src/main/java/pl/project13/core/GitCommitPropertyConstant.java
@@ -188,6 +188,14 @@ public class GitCommitPropertyConstant {
    */
   public static final String CLOSEST_TAG_NAME = "closest.tag.name";
   /**
+   * Represents the tag on the current commit.
+   * Similar to running
+   * <pre>
+   *     git tag --points-at HEAD
+   * </pre>
+   */
+  public static final String TAG = "tag";
+  /**
    * Represents the number of commits to the closest available tag.
    * The closest tag may depend on your git describe config that may or may not take lightweight tags into consideration.
    */

--- a/src/main/java/pl/project13/core/GitDataProvider.java
+++ b/src/main/java/pl/project13/core/GitDataProvider.java
@@ -305,6 +305,7 @@ public abstract class GitDataProvider implements GitProvider {
 
       //
       maybePut(properties, GitCommitPropertyConstant.TAGS, this::getTags);
+      maybePut(properties, GitCommitPropertyConstant.TAG, this::getTag);
 
       maybePut(properties,GitCommitPropertyConstant.CLOSEST_TAG_NAME, this::getClosestTagName);
       maybePut(properties,GitCommitPropertyConstant.CLOSEST_TAG_COMMIT_COUNT, this::getClosestTagCommitCount);

--- a/src/main/java/pl/project13/core/GitProvider.java
+++ b/src/main/java/pl/project13/core/GitProvider.java
@@ -57,6 +57,8 @@ public interface GitProvider {
 
   String getTags() throws GitCommitIdExecutionException;
 
+  String getTag() throws GitCommitIdExecutionException;
+
   String getClosestTagName() throws GitCommitIdExecutionException;
 
   String getClosestTagCommitCount() throws GitCommitIdExecutionException;

--- a/src/main/java/pl/project13/core/JGitProvider.java
+++ b/src/main/java/pl/project13/core/JGitProvider.java
@@ -257,6 +257,19 @@ public class JGitProvider extends GitDataProvider {
   }
 
   @Override
+  public String getTag() throws GitCommitIdExecutionException {
+    try {
+      Repository repo = getGitRepository();
+      ObjectId headId = evalCommit.toObjectId();
+      Collection<String> tags = jGitCommon.getTag(repo, headId);
+      return String.join(",", tags);
+    } catch (GitAPIException e) {
+      log.error(String.format("Unable to extract tag from commit: %s", evalCommit.getName()), e);
+      return "";
+    }
+  }
+
+  @Override
   public String getClosestTagName() throws GitCommitIdExecutionException {
     Repository repo = getGitRepository();
     try {

--- a/src/main/java/pl/project13/core/NativeGitProvider.java
+++ b/src/main/java/pl/project13/core/NativeGitProvider.java
@@ -276,6 +276,12 @@ public class NativeGitProvider extends GitDataProvider {
   }
 
   @Override
+  public String getTag() throws GitCommitIdExecutionException {
+    final String result = runQuietGitCommand(canonical, nativeGitTimeoutInMs, "tag --points-at " + evaluateOnCommit);
+    return result.replace('\n', ',');
+  }
+
+  @Override
   public String getRemoteOriginUrl() throws GitCommitIdExecutionException {
     return getOriginRemote(canonical, nativeGitTimeoutInMs);
   }

--- a/src/main/java/pl/project13/core/jgit/JGitCommon.java
+++ b/src/main/java/pl/project13/core/jgit/JGitCommon.java
@@ -78,6 +78,30 @@ public class JGitCommon {
             .collect(Collectors.toList());
   }
 
+  public Collection<String> getTag(Repository repo, final ObjectId objectId) throws GitAPIException {
+    try (Git git = Git.wrap(repo)) {
+      Collection<String> tags = getTagsOnObjectId(git, objectId);
+      return tags;
+    }
+  }
+
+  private Collection<String> getTagsOnObjectId(final Git git, final ObjectId objectId) throws GitAPIException {
+    return git.tagList().call()
+            .stream()
+            .filter(tagRef -> {
+              try {
+                if (objectId.name().equals(tagRef.getObjectId().name())) {
+                  return true;
+                }
+              } catch (Exception ignored) {
+                log.debug(String.format("Failed while getTagOnObjectId [%s] -- ", tagRef));
+              }
+              return false;
+            })
+            .map(tagRef -> trimFullTagName(tagRef.getName()))
+            .collect(Collectors.toList());
+  }
+
   public String getClosestTagName(@Nonnull String evaluateOnCommit, @Nonnull Repository repo, GitDescribeConfig gitDescribe) {
     // TODO: Why does some tests fail when it gets headCommit from JGitprovider?
     RevCommit headCommit = findEvalCommitObjectId(evaluateOnCommit, repo);

--- a/src/test/java/pl/project13/core/GitCommitIdPluginIntegrationTest.java
+++ b/src/test/java/pl/project13/core/GitCommitIdPluginIntegrationTest.java
@@ -982,6 +982,30 @@ public class GitCommitIdPluginIntegrationTest {
 
   @Test
   @Parameters(method = "useNativeGit")
+  public void shouldGenerateTagInformationWhenOnATag(boolean useNativeGit) throws Exception {
+    // given
+    File dotGitDirectory = createTmpDotGitDirectory(AvailableGitTestRepo.ON_A_TAG);
+
+    GitDescribeConfig gitDescribeConfig = createGitDescribeConfig(false, 7);
+    gitDescribeConfig.setDirty("-dirty"); // checking if dirty works as expected
+
+    GitCommitIdPlugin.Callback cb =
+            new GitCommitIdTestCallback()
+                    .setDotGitDirectory(dotGitDirectory)
+                    .setUseNativeGit(useNativeGit)
+                    .setGitDescribeConfig(gitDescribeConfig)
+                    .build();
+    Properties properties = new Properties();
+
+    // when
+    GitCommitIdPlugin.runPlugin(cb, properties);
+
+    // then
+    assertPropertyPresentAndEqual(properties, "git.tag", "v1.0.0");
+  }
+
+  @Test
+  @Parameters(method = "useNativeGit")
   public void shouldGenerateClosestTagInformationWhenOnATagAndDirty(boolean useNativeGit) throws Exception {
     // given
     File dotGitDirectory = createTmpDotGitDirectory(AvailableGitTestRepo.ON_A_TAG_DIRTY);


### PR DESCRIPTION
### Context
<!--- Thank you for your contribution to this project! :-) -->
<!--- Please tell us a bit more what do you indent with your change and how users of the plugin will benefit from it. -->
<!--- If applicable also provide a link to any relevant issue. -->
`${git.tags}` returns all the tags contains the current commit and `${git.closest.tag.name}` could return the tag name not belonging to the commit. A new property is added in this PR, `${git.tag}`, which returns the tag(s) of a certain commit and empty string if the commit doesn't has a tag.

### Contributor Checklist
- [v] Added relevant integration or unit tests to verify the changes
- [v] Update the Readme or any other documentation (including relevant Javadoc)
- [v] Ensured that tests pass locally: `mvn clean package`
- [v] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
