### PR TITLE
Fix commit.committer.time provider

### DIFF
--- a/src/main/java/pl/project13/core/GitDataProvider.java
+++ b/src/main/java/pl/project13/core/GitDataProvider.java
@@ -286,9 +286,9 @@ public abstract class GitDataProvider implements GitProvider {
       maybePut(properties, GitCommitPropertyConstant.COMMIT_ID_ABBREV, this::getAbbrevCommitId);
       // git.dirty
       maybePut(properties, GitCommitPropertyConstant.DIRTY, () -> Boolean.toString(isDirty()));
-      // git.commit.author.name
+      // git.commit.user.name
       maybePut(properties, GitCommitPropertyConstant.COMMIT_AUTHOR_NAME, this::getCommitAuthorName);
-      // git.commit.author.email
+      // git.commit.user.email
       maybePut(properties, GitCommitPropertyConstant.COMMIT_AUTHOR_EMAIL, this::getCommitAuthorEmail);
       // git.commit.message.full
       maybePut(properties, GitCommitPropertyConstant.COMMIT_MESSAGE_FULL, this::getCommitMessageFull);
@@ -299,7 +299,7 @@ public abstract class GitDataProvider implements GitProvider {
       // commit.author.time
       maybePut(properties, GitCommitPropertyConstant.COMMIT_AUTHOR_TIME, this::getCommitAuthorTime);
       // commit.committer.time
-      maybePut(properties, GitCommitPropertyConstant.COMMIT_COMMITTER_TIME, this::getCommitAuthorTime);
+      maybePut(properties, GitCommitPropertyConstant.COMMIT_COMMITTER_TIME, this::getCommitCommitterTime);
       // git remote.origin.url
       maybePut(properties, GitCommitPropertyConstant.REMOTE_ORIGIN_URL, this::getRemoteOriginUrl);
 

--- a/src/test/java/pl/project13/core/AvailableGitTestRepo.java
+++ b/src/test/java/pl/project13/core/AvailableGitTestRepo.java
@@ -68,6 +68,13 @@ public enum AvailableGitTestRepo {
   WITH_TAG_ON_DIFFERENT_BRANCH("src/test/resources/_git_with_tag_on_different_branch"),
   WITH_ONE_COMMIT_WITH_SPECIAL_CHARACTERS("src/test/resources/_git_one_commit_with_umlaut"),
   /**
+   * <pre>
+   * $ log --date=iso-strict --format='%h | cd=%cd | ad=%ad'
+   * 7002d5c | cd=2014-09-19T17:23:04+02:00 | ad=2012-07-04T15:54:01+02:00
+   * </pre>
+   */
+  COMMITTER_DIFFERENT_FROM_AUTHOR("src/test/resources/_git_one_commit_with_umlaut"),
+  /**
     * <pre>
     * b0c6d28b3b83bf7b905321bae67d9ca4c75a203f 2015-06-04 00:50:18 +0200  (HEAD, master)
     * 0e3495783c56589213ee5f2ae8900e2dc1b776c4 2015-06-03 23:59:10 +0200  (tag: v2.0)


### PR DESCRIPTION
The `commit.committer.time` property has accidentally been using the `commit.author.time` provider since its inception. Fix this.

References: https://github.com/git-commit-id/git-commit-id-plugin-core/issues/82
