### PR TITLE
Fix broken AssertJ specifications

### DIFF
--- a/src/test/java/pl/project13/core/GitCommitIdPluginIntegrationTest.java
+++ b/src/test/java/pl/project13/core/GitCommitIdPluginIntegrationTest.java
@@ -947,12 +947,11 @@ public class GitCommitIdPluginIntegrationTest {
       GitCommitIdPlugin.runPlugin(cb, properties);
 
       // then
-      assertThat(properties.stringPropertyNames()).contains("git.commit.id.describe");
+      assertThat(properties).containsKey("git.commit.id.describe");
       assertThat(properties.getProperty("git.commit.id.describe")).startsWith(gitDescribeMatchNeedle);
 
-      assertThat(properties.stringPropertyNames()).contains("git.commit.id.full");
-      assertThat(properties.get("git.commit.id.full")).isNotEqualTo(commitIdOfMatchNeedle);
-      assertThat(properties.get("git.commit.id.full")).isEqualTo(headCommitId);
+      assertThat(headCommitId).isNotEqualTo(commitIdOfMatchNeedle);
+      assertPropertyPresentAndEqual(properties, "git.commit.id.full", headCommitId);
       assertPropertyPresentAndEqual(properties, "git.total.commit.count", "3");
     }
   }
@@ -1123,8 +1122,8 @@ public class GitCommitIdPluginIntegrationTest {
     GitCommitIdPlugin.runPlugin(cb, properties);
 
     // then
-    assertThat(properties.stringPropertyNames()).contains("git.commit.id");
-    assertThat(properties.stringPropertyNames()).doesNotContain("git.commit.id.full");
+    assertThat(properties).containsKey("git.commit.id");
+    assertThat(properties).doesNotContainKey("git.commit.id.full");
   }
 
   @Test
@@ -1563,9 +1562,8 @@ public class GitCommitIdPluginIntegrationTest {
     return gitDescribeConfig;
   }
 
-  private void assertPropertyPresentAndEqual(Properties properties, String key, String expected) {
-    assertThat(properties.stringPropertyNames()).contains(key);
-    assertThat(properties.getProperty(key)).isEqualTo(expected);
+  private static void assertPropertyPresentAndEqual(Properties properties, String key, String expected) {
+    assertThat(properties).containsEntry(key, expected);
   }
 
   private static void assertGitPropertiesPresentInProject(Properties properties) {

--- a/src/test/java/pl/project13/core/GitCommitIdPluginIntegrationTest.java
+++ b/src/test/java/pl/project13/core/GitCommitIdPluginIntegrationTest.java
@@ -73,7 +73,7 @@ public class GitCommitIdPluginIntegrationTest {
     }
   }
 
-  @Test(expected = AssertionError.class)
+  @Test
   @Parameters(method = "useNativeGit")
   public void shouldIncludeExpectedProperties(boolean useNativeGit) throws Exception {
     // given
@@ -92,7 +92,7 @@ public class GitCommitIdPluginIntegrationTest {
     // then
     assertThat(properties).containsKey("git.branch");
     assertThat(properties).containsKey("git.dirty");
-    assertThat(properties).containsKey("git.commit.id.full");
+    assertThat(properties).containsKey("git.commit.id");
     assertThat(properties).containsKey("git.commit.id.abbrev");
     assertThat(properties).containsKey("git.build.user.name");
     assertThat(properties).containsKey("git.build.user.email");
@@ -104,7 +104,7 @@ public class GitCommitIdPluginIntegrationTest {
     assertThat(properties).containsKey("git.remote.origin.url");
   }
 
-  @Test(expected = AssertionError.class)
+  @Test
   @Parameters(method = "useNativeGit")
   public void shouldExcludeAsConfiguredProperties(boolean useNativeGit) throws Exception {
     // given
@@ -134,14 +134,14 @@ public class GitCommitIdPluginIntegrationTest {
 
     // these stay
     assertThat(properties).containsKey("git.branch");
-    assertThat(properties).containsKey("git.commit.id.full");
+    assertThat(properties).containsKey("git.commit.id");
     assertThat(properties).containsKey("git.commit.id.abbrev");
     assertThat(properties).containsKey("git.commit.message.full");
     assertThat(properties).containsKey("git.commit.message.short");
     assertThat(properties).containsKey("git.commit.time");
   }
 
-  @Test(expected = AssertionError.class)
+  @Test
   @Parameters(method = "useNativeGit")
   public void shouldIncludeOnlyAsConfiguredProperties(boolean useNativeGit) throws Exception {
     // given
@@ -151,6 +151,7 @@ public class GitCommitIdPluginIntegrationTest {
             new GitCommitIdTestCallback()
                     .setDotGitDirectory(dotGitDirectory)
                     .setUseNativeGit(useNativeGit)
+                    .setCommitIdGenerationMode(CommitIdGenerationMode.FULL)
                     .setIncludeOnlyProperties(Arrays.asList("git.remote.origin.url", ".*.user.*", "^git.commit.id.full$"))
                     .build();
     Properties properties = new Properties();
@@ -170,6 +171,7 @@ public class GitCommitIdPluginIntegrationTest {
 
     // these excluded
     assertThat(properties).doesNotContainKey("git.branch");
+    assertThat(properties).doesNotContainKey("git.commit.id");
     assertThat(properties).doesNotContainKey("git.commit.id.abbrev");
     assertThat(properties).doesNotContainKey("git.commit.message.full");
     assertThat(properties).doesNotContainKey("git.commit.message.short");
@@ -209,6 +211,7 @@ public class GitCommitIdPluginIntegrationTest {
 
     // these excluded
     assertThat(properties).doesNotContainKey("git.branch");
+    assertThat(properties).doesNotContainKey("git.commit.id");
     assertThat(properties).doesNotContainKey("git.commit.id.full");
     assertThat(properties).doesNotContainKey("git.commit.id.abbrev");
     assertThat(properties).doesNotContainKey("git.commit.message.full");
@@ -375,7 +378,7 @@ public class GitCommitIdPluginIntegrationTest {
     assertPropertyPresentAndEqual(properties, "git.branch", expectedBranchName);
   }
 
-  @Test(expected = AssertionError.class)
+  @Test
   @Parameters(method = "useNativeGit")
   public void shouldResolvePropertiesOnDefaultSettingsForNonPomProject(boolean useNativeGit) throws Exception {
     // given
@@ -667,7 +670,7 @@ public class GitCommitIdPluginIntegrationTest {
     assertThat(properties).contains(entry("git.commit.id.abbrev", "de4db35917"));
   }
 
-  @Test(expected = AssertionError.class)
+  @Test
   @Parameters(method = "useNativeGit")
   public void shouldFormatDate(boolean useNativeGit) throws Exception {
     // given
@@ -768,7 +771,7 @@ public class GitCommitIdPluginIntegrationTest {
     assertPropertyPresentAndEqual(properties, "git.commit.id.describe", "0b0181b");
   }
 
-  @Test(expected = AssertionError.class)
+  @Test
   @Parameters(method = "useNativeGit")
   public void shouldWorkWithEmptyGitDescribe(boolean useNativeGit) throws Exception {
     // given
@@ -791,7 +794,7 @@ public class GitCommitIdPluginIntegrationTest {
     assertGitPropertiesPresentInProject(properties);
   }
 
-  @Test(expected = AssertionError.class)
+  @Test
   @Parameters(method = "useNativeGit")
   public void shouldWorkWithNullGitDescribe(boolean useNativeGit) throws Exception {
     // given
@@ -814,7 +817,7 @@ public class GitCommitIdPluginIntegrationTest {
     assertGitPropertiesPresentInProject(properties);
   }
 
-  @Test(expected = AssertionError.class)
+  @Test
   @Parameters(method = "useNativeGit")
   public void shouldExtractTagsOnGivenCommit(boolean useNativeGit) throws Exception {
     // given
@@ -848,7 +851,7 @@ public class GitCommitIdPluginIntegrationTest {
     assertPropertyPresentAndEqual(properties, "git.total.commit.count", "2");
   }
 
-  @Test(expected = AssertionError.class)
+  @Test
   @Parameters(method = "useNativeGit")
   public void shouldExtractTagsOnGivenCommitWithOldestCommit(boolean useNativeGit) throws Exception {
     // given
@@ -883,7 +886,7 @@ public class GitCommitIdPluginIntegrationTest {
     assertPropertyPresentAndEqual(properties, "git.total.commit.count", "1");
   }
 
-  @Test(expected = AssertionError.class)
+  @Test
   @Parameters(method = "useNativeGit")
   public void shouldExtractTagsOnHead(boolean useNativeGit) throws Exception {
     // given
@@ -1569,7 +1572,7 @@ public class GitCommitIdPluginIntegrationTest {
     assertThat(properties).containsKey("git.build.time");
     assertThat(properties).containsKey("git.build.host");
     assertThat(properties).containsKey("git.branch");
-    assertThat(properties).containsKey("git.commit.id.full");
+    assertThat(properties).containsKey("git.commit.id");
     assertThat(properties).containsKey("git.commit.id.abbrev");
     assertThat(properties).containsKey("git.commit.id.describe");
     assertThat(properties).containsKey("git.build.user.name");

--- a/src/test/java/pl/project13/core/GitCommitIdPluginIntegrationTest.java
+++ b/src/test/java/pl/project13/core/GitCommitIdPluginIntegrationTest.java
@@ -73,7 +73,7 @@ public class GitCommitIdPluginIntegrationTest {
     }
   }
 
-  @Test
+  @Test(expected = AssertionError.class)
   @Parameters(method = "useNativeGit")
   public void shouldIncludeExpectedProperties(boolean useNativeGit) throws Exception {
     // given
@@ -90,21 +90,21 @@ public class GitCommitIdPluginIntegrationTest {
     GitCommitIdPlugin.runPlugin(cb, properties);
 
     // then
-    assertThat(properties.contains("git.branch"));
-    assertThat(properties.contains("git.dirty"));
-    assertThat(properties.contains("git.commit.id.full"));
-    assertThat(properties.contains("git.commit.id.abbrev"));
-    assertThat(properties.contains("git.build.user.name"));
-    assertThat(properties.contains("git.build.user.email"));
-    assertThat(properties.contains("git.commit.user.name"));
-    assertThat(properties.contains("git.commit.user.email"));
-    assertThat(properties.contains("git.commit.message.full"));
-    assertThat(properties.contains("git.commit.message.short"));
-    assertThat(properties.contains("git.commit.time"));
-    assertThat(properties.contains("git.remote.origin.url"));
+    assertThat(properties).containsKey("git.branch");
+    assertThat(properties).containsKey("git.dirty");
+    assertThat(properties).containsKey("git.commit.id.full");
+    assertThat(properties).containsKey("git.commit.id.abbrev");
+    assertThat(properties).containsKey("git.build.user.name");
+    assertThat(properties).containsKey("git.build.user.email");
+    assertThat(properties).containsKey("git.commit.user.name");
+    assertThat(properties).containsKey("git.commit.user.email");
+    assertThat(properties).containsKey("git.commit.message.full");
+    assertThat(properties).containsKey("git.commit.message.short");
+    assertThat(properties).containsKey("git.commit.time");
+    assertThat(properties).containsKey("git.remote.origin.url");
   }
 
-  @Test
+  @Test(expected = AssertionError.class)
   @Parameters(method = "useNativeGit")
   public void shouldExcludeAsConfiguredProperties(boolean useNativeGit) throws Exception {
     // given
@@ -124,24 +124,24 @@ public class GitCommitIdPluginIntegrationTest {
     // then
 
     // explicitly excluded
-    assertThat(! properties.contains("git.remote.origin.url"));
+    assertThat(properties).doesNotContainKey("git.remote.origin.url");
 
     // glob excluded
-    assertThat(! properties.contains("git.build.user.name"));
-    assertThat(! properties.contains("git.build.user.email"));
-    assertThat(! properties.contains("git.commit.user.name"));
-    assertThat(! properties.contains("git.commit.user.email"));
+    assertThat(properties).doesNotContainKey("git.build.user.name");
+    assertThat(properties).doesNotContainKey("git.build.user.email");
+    assertThat(properties).doesNotContainKey("git.commit.user.name");
+    assertThat(properties).doesNotContainKey("git.commit.user.email");
 
     // these stay
-    assertThat(properties.contains("git.branch"));
-    assertThat(properties.contains("git.commit.id.full"));
-    assertThat(properties.contains("git.commit.id.abbrev"));
-    assertThat(properties.contains("git.commit.message.full"));
-    assertThat(properties.contains("git.commit.message.short"));
-    assertThat(properties.contains("git.commit.time"));
+    assertThat(properties).containsKey("git.branch");
+    assertThat(properties).containsKey("git.commit.id.full");
+    assertThat(properties).containsKey("git.commit.id.abbrev");
+    assertThat(properties).containsKey("git.commit.message.full");
+    assertThat(properties).containsKey("git.commit.message.short");
+    assertThat(properties).containsKey("git.commit.time");
   }
 
-  @Test
+  @Test(expected = AssertionError.class)
   @Parameters(method = "useNativeGit")
   public void shouldIncludeOnlyAsConfiguredProperties(boolean useNativeGit) throws Exception {
     // given
@@ -159,21 +159,21 @@ public class GitCommitIdPluginIntegrationTest {
     GitCommitIdPlugin.runPlugin(cb, properties);
 
     // explicitly included
-    assertThat(properties.contains("git.remote.origin.url"));
+    assertThat(properties).containsKey("git.remote.origin.url");
 
     // glob included
-    assertThat(properties.contains("git.build.user.name"));
-    assertThat(properties.contains("git.build.user.email"));
-    assertThat(properties.contains("git.commit.id.full"));
-    assertThat(properties.contains("git.commit.user.name"));
-    assertThat(properties.contains("git.commit.user.email"));
+    assertThat(properties).containsKey("git.build.user.name");
+    assertThat(properties).containsKey("git.build.user.email");
+    assertThat(properties).containsKey("git.commit.id.full");
+    assertThat(properties).containsKey("git.commit.user.name");
+    assertThat(properties).containsKey("git.commit.user.email");
 
     // these excluded
-    assertThat(! properties.contains("git.branch"));
-    assertThat(! properties.contains("git.commit.id.abbrev"));
-    assertThat(! properties.contains("git.commit.message.full"));
-    assertThat(! properties.contains("git.commit.message.short"));
-    assertThat(! properties.contains("git.commit.time"));
+    assertThat(properties).doesNotContainKey("git.branch");
+    assertThat(properties).doesNotContainKey("git.commit.id.abbrev");
+    assertThat(properties).doesNotContainKey("git.commit.message.full");
+    assertThat(properties).doesNotContainKey("git.commit.message.short");
+    assertThat(properties).doesNotContainKey("git.commit.time");
   }
 
   @Test
@@ -197,23 +197,23 @@ public class GitCommitIdPluginIntegrationTest {
     // then
 
     // explicitly included
-    assertThat(properties.contains("git.remote.origin.url"));
+    assertThat(properties).containsKey("git.remote.origin.url");
 
     // explicitly excluded -> overrules include only properties
-    assertThat(! properties.contains("git.build.user.email"));
+    assertThat(properties).doesNotContainKey("git.build.user.email");
 
     // glob included
-    assertThat(properties.contains("git.build.user.name"));
-    assertThat(properties.contains("git.commit.user.name"));
-    assertThat(properties.contains("git.commit.user.email"));
+    assertThat(properties).containsKey("git.build.user.name");
+    assertThat(properties).containsKey("git.commit.user.name");
+    assertThat(properties).containsKey("git.commit.user.email");
 
     // these excluded
-    assertThat(! properties.contains("git.branch"));
-    assertThat(! properties.contains("git.commit.id.full"));
-    assertThat(! properties.contains("git.commit.id.abbrev"));
-    assertThat(! properties.contains("git.commit.message.full"));
-    assertThat(! properties.contains("git.commit.message.short"));
-    assertThat(! properties.contains("git.commit.time"));
+    assertThat(properties).doesNotContainKey("git.branch");
+    assertThat(properties).doesNotContainKey("git.commit.id.full");
+    assertThat(properties).doesNotContainKey("git.commit.id.abbrev");
+    assertThat(properties).doesNotContainKey("git.commit.message.full");
+    assertThat(properties).doesNotContainKey("git.commit.message.short");
+    assertThat(properties).doesNotContainKey("git.commit.time");
   }
 
   @Test
@@ -235,9 +235,9 @@ public class GitCommitIdPluginIntegrationTest {
 
     // then
     // explicitly excluded
-    assertThat(! properties.contains("git.remote.origin.url"));
-    assertThat(! properties.contains(".remote.origin.url"));
-    assertThat(properties.contains("remote.origin.url"));
+    assertThat(properties).doesNotContainKey("git.remote.origin.url");
+    assertThat(properties).doesNotContainKey(".remote.origin.url");
+    assertThat(properties).containsKey("remote.origin.url");
   }
 
   @Test
@@ -261,7 +261,7 @@ public class GitCommitIdPluginIntegrationTest {
     GitCommitIdPlugin.runPlugin(cb, properties);
 
     // then
-    assertThat(! properties.contains("git.commit.id.describe"));
+    assertThat(properties).doesNotContainKey("git.commit.id.describe");
   }
   
   @Test
@@ -375,7 +375,7 @@ public class GitCommitIdPluginIntegrationTest {
     assertPropertyPresentAndEqual(properties, "git.branch", expectedBranchName);
   }
 
-  @Test
+  @Test(expected = AssertionError.class)
   @Parameters(method = "useNativeGit")
   public void shouldResolvePropertiesOnDefaultSettingsForNonPomProject(boolean useNativeGit) throws Exception {
     // given
@@ -466,7 +466,7 @@ public class GitCommitIdPluginIntegrationTest {
     // then
     assertThat(targetFilePath).exists();
     Properties p = GenericFileManager.readPropertiesAsUtf8(commitIdPropertiesOutputFormat, targetFilePath);
-    assertThat(p.size() > 10);
+    assertThat(p).hasSizeGreaterThan(10);
     Assert.assertEquals(p, properties);
   }
 
@@ -495,7 +495,7 @@ public class GitCommitIdPluginIntegrationTest {
     // then
     assertThat(targetFilePath).exists();
     Properties p = GenericFileManager.readPropertiesAsUtf8(commitIdPropertiesOutputFormat, targetFilePath);
-    assertThat(p.size() > 10);
+    assertThat(p).hasSizeGreaterThan(10);
     Assert.assertEquals(p, properties);
   }
 
@@ -524,7 +524,7 @@ public class GitCommitIdPluginIntegrationTest {
     // then
     assertThat(targetFilePath).exists();
     Properties p = GenericFileManager.readPropertiesAsUtf8(commitIdPropertiesOutputFormat, targetFilePath);
-    assertThat(p.size() > 10);
+    assertThat(p).hasSizeGreaterThan(10);
     Assert.assertEquals(p, properties);
   }
 
@@ -667,7 +667,7 @@ public class GitCommitIdPluginIntegrationTest {
     assertThat(properties).contains(entry("git.commit.id.abbrev", "de4db35917"));
   }
 
-  @Test
+  @Test(expected = AssertionError.class)
   @Parameters(method = "useNativeGit")
   public void shouldFormatDate(boolean useNativeGit) throws Exception {
     // given
@@ -716,7 +716,7 @@ public class GitCommitIdPluginIntegrationTest {
     GitCommitIdPlugin.runPlugin(cb, properties);
 
     // then
-    assertThat(! properties.contains("git.commit.id.describe"));
+    assertThat(properties).doesNotContainKey("git.commit.id.describe");
   }
 
   @Test
@@ -768,7 +768,7 @@ public class GitCommitIdPluginIntegrationTest {
     assertPropertyPresentAndEqual(properties, "git.commit.id.describe", "0b0181b");
   }
 
-  @Test
+  @Test(expected = AssertionError.class)
   @Parameters(method = "useNativeGit")
   public void shouldWorkWithEmptyGitDescribe(boolean useNativeGit) throws Exception {
     // given
@@ -791,7 +791,7 @@ public class GitCommitIdPluginIntegrationTest {
     assertGitPropertiesPresentInProject(properties);
   }
 
-  @Test
+  @Test(expected = AssertionError.class)
   @Parameters(method = "useNativeGit")
   public void shouldWorkWithNullGitDescribe(boolean useNativeGit) throws Exception {
     // given
@@ -814,7 +814,7 @@ public class GitCommitIdPluginIntegrationTest {
     assertGitPropertiesPresentInProject(properties);
   }
 
-  @Test
+  @Test(expected = AssertionError.class)
   @Parameters(method = "useNativeGit")
   public void shouldExtractTagsOnGivenCommit(boolean useNativeGit) throws Exception {
     // given
@@ -840,7 +840,7 @@ public class GitCommitIdPluginIntegrationTest {
     // then
     assertGitPropertiesPresentInProject(properties);
 
-    assertThat(properties.contains("git.tags"));
+    assertThat(properties).containsKey("git.tags");
     assertThat(properties.get("git.tags").toString()).doesNotContain("refs/tags/");
 
     assertThat(Arrays.asList(properties.get("git.tags").toString().split(",")))
@@ -848,7 +848,7 @@ public class GitCommitIdPluginIntegrationTest {
     assertPropertyPresentAndEqual(properties, "git.total.commit.count", "2");
   }
 
-  @Test
+  @Test(expected = AssertionError.class)
   @Parameters(method = "useNativeGit")
   public void shouldExtractTagsOnGivenCommitWithOldestCommit(boolean useNativeGit) throws Exception {
     // given
@@ -875,7 +875,7 @@ public class GitCommitIdPluginIntegrationTest {
     // then
     assertGitPropertiesPresentInProject(properties);
 
-    assertThat(properties.contains("git.tags"));
+    assertThat(properties).containsKey("git.tags");
     assertThat(properties.get("git.tags").toString()).doesNotContain("refs/tags/");
 
     assertThat(Arrays.asList(properties.get("git.tags").toString().split(",")))
@@ -883,7 +883,7 @@ public class GitCommitIdPluginIntegrationTest {
     assertPropertyPresentAndEqual(properties, "git.total.commit.count", "1");
   }
 
-  @Test
+  @Test(expected = AssertionError.class)
   @Parameters(method = "useNativeGit")
   public void shouldExtractTagsOnHead(boolean useNativeGit) throws Exception {
     // given
@@ -905,7 +905,7 @@ public class GitCommitIdPluginIntegrationTest {
     // then
     assertGitPropertiesPresentInProject(properties);
 
-    assertThat(properties.contains("git.tags"));
+    assertThat(properties).containsKey("git.tags");
     assertThat(properties.get("git.tags").toString()).doesNotContain("refs/tags/");
 
     assertThat(Arrays.asList(properties.get("git.tags").toString().split(",")))
@@ -1565,23 +1565,23 @@ public class GitCommitIdPluginIntegrationTest {
     assertThat(properties.getProperty(key)).isEqualTo(expected);
   }
 
-  private void assertGitPropertiesPresentInProject(Properties properties) {
-    assertThat(properties.contains("git.build.time"));
-    assertThat(properties.contains("git.build.host"));
-    assertThat(properties.contains("git.branch"));
-    assertThat(properties.contains("git.commit.id.full"));
-    assertThat(properties.contains("git.commit.id.abbrev"));
-    assertThat(properties.contains("git.commit.id.describe"));
-    assertThat(properties.contains("git.build.user.name"));
-    assertThat(properties.contains("git.build.user.email"));
-    assertThat(properties.contains("git.commit.user.name"));
-    assertThat(properties.contains("git.commit.user.email"));
-    assertThat(properties.contains("git.commit.message.full"));
-    assertThat(properties.contains("git.commit.message.short"));
-    assertThat(properties.contains("git.commit.time"));
-    assertThat(properties.contains("git.remote.origin.url"));
-    assertThat(properties.contains("git.closest.tag.name"));
-    assertThat(properties.contains("git.closest.tag.commit.count"));
+  private static void assertGitPropertiesPresentInProject(Properties properties) {
+    assertThat(properties).containsKey("git.build.time");
+    assertThat(properties).containsKey("git.build.host");
+    assertThat(properties).containsKey("git.branch");
+    assertThat(properties).containsKey("git.commit.id.full");
+    assertThat(properties).containsKey("git.commit.id.abbrev");
+    assertThat(properties).containsKey("git.commit.id.describe");
+    assertThat(properties).containsKey("git.build.user.name");
+    assertThat(properties).containsKey("git.build.user.email");
+    assertThat(properties).containsKey("git.commit.user.name");
+    assertThat(properties).containsKey("git.commit.user.email");
+    assertThat(properties).containsKey("git.commit.message.full");
+    assertThat(properties).containsKey("git.commit.message.short");
+    assertThat(properties).containsKey("git.commit.time");
+    assertThat(properties).containsKey("git.remote.origin.url");
+    assertThat(properties).containsKey("git.closest.tag.name");
+    assertThat(properties).containsKey("git.closest.tag.commit.count");
   }
 
   private File createTmpDotGitDirectory(@Nonnull AvailableGitTestRepo availableGitTestRepo) throws IOException {


### PR DESCRIPTION
A number of specifications expressed with AssertJ invoke the API incorrectly, leaving the assertions ineffectual. Fixing these reveals that several test cases express minor expectations that are not met by the implementation and require review for correctness -- there is strong evidence that the expectations, not the implementation, are in error, namely by way of `commit.id` being default and mutually exclusive with `commit.id.full`. Additionally, some expectations can trivially be expressed with more AssertJ-native assertion operators.

This PR restores function to the nonfunctional expectations, attempts to correct the resulting broken tests, and superficially rewrites AssertJ-expectations into more native variants.