### PR TITLE
https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/701: Fix an issue with submodules

### DIFF
--- a/src/main/java/pl/project13/core/GitCommitIdPlugin.java
+++ b/src/main/java/pl/project13/core/GitCommitIdPlugin.java
@@ -359,28 +359,17 @@ public class GitCommitIdPlugin {
     }
   }
 
-  private static File findDotGitDirectory(@Nonnull Callback cb) throws GitCommitIdExecutionException {
-    File dotGitDirectory = lookupGitDirectory(cb);
-    if (cb.shouldFailOnNoGitDirectory() && !directoryExists(dotGitDirectory)) {
-      throw new GitCommitIdExecutionException(
-        ".git directory is not found! Please specify a valid [dotGitDirectory] in your"
-          + " project");
-    }
-    return dotGitDirectory;
-  }
-
-  private static boolean directoryExists(@Nullable File fileLocation) {
-    return fileLocation != null && fileLocation.exists() && fileLocation.isDirectory();
-  }
-
   /**
    * Find the git directory of the currently used project. If it's not already specified, this
    * method will try to find it.
    *
    * @return the File representation of the .git directory
    */
-  private static File lookupGitDirectory(@Nonnull Callback cb) throws GitCommitIdExecutionException {
-    return new GitDirLocator(cb.getProjectBaseDir()).lookupGitDirectory(cb.getDotGitDirectory());
+  private static File findDotGitDirectory(@Nonnull Callback cb) throws GitCommitIdExecutionException {
+    return new GitDirLocator(
+      cb.getProjectBaseDir(),
+      cb.shouldFailOnNoGitDirectory()
+    ).lookupGitDirectory(cb.getDotGitDirectory());
   }
 
   private static void loadGitDataWithNativeGit(

--- a/src/main/java/pl/project13/core/GitCommitIdPlugin.java
+++ b/src/main/java/pl/project13/core/GitCommitIdPlugin.java
@@ -344,7 +344,11 @@ public class GitCommitIdPlugin {
       throw new GitCommitIdExecutionException("suspicious argument for evaluateOnCommit, aborting execution!");
     }
 
-    File dotGitDirectory = findDotGitDirectory(cb);
+    File dotGitDirectory = new GitDirLocator(
+        cb.getProjectBaseDir(),
+        cb.useNativeGit(),
+        cb.shouldFailOnNoGitDirectory()
+    ).lookupGitDirectory(cb.getDotGitDirectory());
     if (dotGitDirectory != null) {
       cb.getLogInterface().info("dotGitDirectory '" + dotGitDirectory.getAbsolutePath() + "'");
     } else {
@@ -359,25 +363,12 @@ public class GitCommitIdPlugin {
     }
   }
 
-  /**
-   * Find the git directory of the currently used project. If it's not already specified, this
-   * method will try to find it.
-   *
-   * @return the File representation of the .git directory
-   */
-  private static File findDotGitDirectory(@Nonnull Callback cb) throws GitCommitIdExecutionException {
-    return new GitDirLocator(
-      cb.getProjectBaseDir(),
-      cb.shouldFailOnNoGitDirectory()
-    ).lookupGitDirectory(cb.getDotGitDirectory());
-  }
-
   private static void loadGitDataWithNativeGit(
       @Nonnull Callback cb,
       @Nonnull File dotGitDirectory,
       @Nonnull Properties properties) throws GitCommitIdExecutionException {
     GitDataProvider nativeGitProvider = NativeGitProvider
-            .on(dotGitDirectory.getParentFile(), cb.getNativeGitTimeoutInMs(), cb.getLogInterface())
+            .on(dotGitDirectory, cb.getNativeGitTimeoutInMs(), cb.getLogInterface())
             .setPrefixDot(cb.getPrefixDot())
             .setAbbrevLength(cb.getAbbrevLength())
             .setDateFormat(cb.getDateFormat())

--- a/src/main/java/pl/project13/core/util/GitDirLocator.java
+++ b/src/main/java/pl/project13/core/util/GitDirLocator.java
@@ -33,6 +33,7 @@ import pl.project13.core.GitCommitIdExecutionException;
  */
 public class GitDirLocator {
   final File projectBasedir;
+  final boolean useNativeGit;
   final boolean shouldFailOnNoGitDirectory;
 
   /**
@@ -40,9 +41,19 @@ public class GitDirLocator {
    *
    * @param projectBasedir The project basedir that will be used as last resort to search
    *                       the parent project hierarchy until a .git directory is found.
+   * @param useNativeGit Boolean that indicates if we use the native git implementation or the
+   *                     jGit Implementation. For the native git we usually need to
+   *                     use the parent "git"-Folder, as git can not run commands
+   *                     in "your-project/.git".
+   * @param shouldFailOnNoGitDirectory Boolean that indicates if the process should fail if no
+   *                                   git directory can be found.
    */
-  public GitDirLocator(File projectBasedir, boolean shouldFailOnNoGitDirectory) {
+  public GitDirLocator(
+      File projectBasedir,
+      boolean useNativeGit,
+      boolean shouldFailOnNoGitDirectory) {
     this.projectBasedir = projectBasedir;
+    this.useNativeGit = useNativeGit;
     this.shouldFailOnNoGitDirectory = shouldFailOnNoGitDirectory;
   }
 
@@ -62,6 +73,9 @@ public class GitDirLocator {
       throw new GitCommitIdExecutionException(
         ".git directory is not found! Please specify a valid [dotGitDirectory] in your"
           + " project");
+    }
+    if (useNativeGit) {
+      dotGitDirectory = dotGitDirectory.getParentFile();
     }
     return dotGitDirectory;
   }

--- a/src/main/java/pl/project13/core/util/GitDirLocator.java
+++ b/src/main/java/pl/project13/core/util/GitDirLocator.java
@@ -1,0 +1,173 @@
+/*
+ * This file is part of git-commit-id-plugin-core by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ *
+ * git-commit-id-plugin-core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * git-commit-id-plugin-core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with git-commit-id-plugin-core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pl.project13.core.util;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Path;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.eclipse.jgit.lib.Constants;
+
+/**
+ * This class encapsulates logic to locate a valid .git directory of the currently used project. If
+ * it's not already specified, this logic will try to find it.
+ */
+public class GitDirLocator {
+  final File projectBasedir;
+
+  /**
+   * Constructor to encapsulates all references required to locate a valid .git directory
+   *
+   * @param projectBasedir The project basedir that will be used as last resort to search
+   *                       the parent project hierarchy until a .git directory is found.
+   */
+  public GitDirLocator(File projectBasedir) {
+    this.projectBasedir = projectBasedir;
+  }
+
+  /**
+   * Attempts to lookup a valid .git directory of the currently used project.
+   *
+   * @param manuallyConfiguredDir A user has the ability to configure a git-directory with the
+   *     {@code dotGitDirectory} configuration setting. By default it should be simply {@code
+   *     ${project.basedir}/.git}
+   * @return A valid .git directory, or {@code null} if none could be found under the user specified
+   *     location or within the project or it's reactor projects.
+   */
+  @Nullable
+  public File lookupGitDirectory(@Nonnull File manuallyConfiguredDir) {
+    if (manuallyConfiguredDir.exists()) {
+
+      // If manuallyConfiguredDir is a directory then we can use it as the git path.
+      if (manuallyConfiguredDir.isDirectory()) {
+        return manuallyConfiguredDir;
+      }
+
+      // If the path exists but is not a directory it might be a git submodule "gitdir" link.
+      File gitDirLinkPath = processGitDirFile(manuallyConfiguredDir);
+
+      // If the linkPath was found from the file and it exists then use it.
+      if (isExistingDirectory(gitDirLinkPath)) {
+        return gitDirLinkPath;
+      }
+
+      /*
+       * FIXME: I think we should fail here because a manual path was set and it was not found
+       * but I'm leaving it falling back to searching for the git path because that is the current
+       * behaviour - Unluckypixie.
+       */
+    }
+
+    return findProjectGitDirectory();
+  }
+
+  /**
+   * Search up all the parent project hierarchy until a .git directory is found.
+   *
+   * @return File which represents the location of the .git directory or NULL if none found.
+   */
+  @Nullable
+  private File findProjectGitDirectory() {
+    File basedir = this.projectBasedir;
+    while (basedir != null) {
+      File gitdir = new File(basedir, Constants.DOT_GIT);
+      if (gitdir.exists()) {
+        if (gitdir.isDirectory()) {
+          return gitdir;
+        } else if (gitdir.isFile()) {
+          return processGitDirFile(gitdir);
+        } else {
+          return null;
+        }
+      }
+      basedir = basedir.getParentFile();
+    }
+    return null;
+  }
+
+  /**
+   * Load a ".git" git submodule file and read the gitdir path from it.
+   *
+   * @return File object with path loaded or null
+   */
+  private File processGitDirFile(@Nonnull File file) {
+    try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+      // There should be just one line in the file, e.g.
+      // "gitdir: /usr/local/src/parentproject/.git/modules/submodule"
+      String line = reader.readLine();
+      if (line == null) {
+        return null;
+      }
+      // Separate the key and the value in the string.
+      String[] parts = line.split(": ");
+
+      // If we don't have 2 parts or if the key is not gitdir then give up.
+      if (parts.length != 2 || !parts[0].equals("gitdir")) {
+        return null;
+      }
+
+      // All seems ok so return the "gitdir" value read from the file.
+      String extractFromConfig = parts[1];
+      File gitDir = resolveWorktree(new File(extractFromConfig));
+      if (gitDir.isAbsolute()) {
+        // gitdir value is an absolute path. Return as-is
+        return gitDir;
+      } else {
+        // gitdir value is relative.
+        return new File(file.getParentFile(), extractFromConfig);
+      }
+    } catch (IOException e) {
+      return null;
+    }
+  }
+
+  /**
+   * Attempts to resolve the actual location of the .git folder for a given
+   * worktree.
+   * For example for a worktree like {@code a/.git/worktrees/X} structure would
+   * return {@code a/.git}.
+   *
+   * If the conditions for a git worktree like file structure are met simply return the provided
+   * argument as is.
+   */
+  static File resolveWorktree(File fileLocation) {
+    Path parent = fileLocation.toPath().getParent();
+    if (parent == null) {
+      return fileLocation;
+    }
+    if (parent.endsWith(Path.of(".git", "worktrees"))) {
+      return parent.getParent().toFile();
+    }
+    return fileLocation;
+  }
+
+  /**
+   * Helper method to validate that the specified {@code File} is an existing directory.
+   *
+   * @param fileLocation The {@code File} that should be checked if it's actually an existing
+   *     directory.
+   * @return {@code true} if the specified {@code File} is an existing directory, {@false}
+   *     otherwise.
+   */
+  private static boolean isExistingDirectory(@Nullable File fileLocation) {
+    return fileLocation != null && fileLocation.exists() && fileLocation.isDirectory();
+  }
+}

--- a/src/main/java/pl/project13/core/util/GitDirLocator.java
+++ b/src/main/java/pl/project13/core/util/GitDirLocator.java
@@ -74,7 +74,7 @@ public class GitDirLocator {
         ".git directory is not found! Please specify a valid [dotGitDirectory] in your"
           + " project");
     }
-    // assert dotGitDirectory != null
+    // dotGitDirectory can be null here, when shouldFailOnNoGitDirectory == true
     if (useNativeGit) {
       // Check if the resolved directory structure looks like it is a submodule
       // path like `your-project/.git/modules/remote-module`.

--- a/src/test/java/pl/project13/core/AvailableGitTestRepo.java
+++ b/src/test/java/pl/project13/core/AvailableGitTestRepo.java
@@ -48,7 +48,41 @@ public enum AvailableGitTestRepo {
    */
   WITH_COMMIT_THAT_HAS_TWO_TAGS("src/test/resources/_git_with_commit_that_has_two_tags"),
   ON_A_TAG_DIRTY("src/test/resources/_git_on_a_tag_dirty"),
+  /**
+   * <pre>
+   * * 01ed93c - (11 years ago) any commit, just a readme - Konrad Malawski (HEAD -> master)
+   * * 4ce26eb - (11 years ago) my submodules, yay - Konrad Malawski
+   * </pre>
+   * <pre>
+   * $ git submodule status
+   * -9fd4b69a5ca09b60884d4f8f49ce16ea071077be module1
+   * -9fd4b69a5ca09b60884d4f8f49ce16ea071077be module2
+   * -9fd4b69a5ca09b60884d4f8f49ce16ea071077be module3
+   * -9fd4b69a5ca09b60884d4f8f49ce16ea071077be module4
+   *
+   * $ git config --file .gitmodules --get-regexp '\.url$'
+   * submodule.module1.url /tmp/module1
+   * submodule.module2.url /tmp/module1
+   * submodule.module3.url /tmp/module1
+   * submodule.module4.url /tmp/module1
+   * </pre>
+   */
   WITH_SUBMODULES("src/test/resources/_git_with_submodules"),
+
+  /**
+   * <pre>
+   * 6455ccd - (3 minutes ago) init (HEAD -> master)
+   * </pre>
+   * <pre>
+   * $ git submodule status
+   * 945bfe60e8a3eff168e915c7ba5bac37c9d0165b remote-module (heads/empty-branch)
+   *
+   * $ git submodule foreach --recursive git remote get-url origin
+   * Entering 'remote-module'
+   * git@github.com:git-commit-id/git-test-resources.git
+   * </pre>
+   */
+  WITH_REMOTE_SUBMODULES("src/test/resources/_git_with_remote_submodules"),
   /**
    * <pre>
    * b6a73ed - (HEAD, master) third addition (4 minutes ago) <p>Konrad Malawski</p>

--- a/src/test/java/pl/project13/core/GitCommitIdPluginIntegrationTest.java
+++ b/src/test/java/pl/project13/core/GitCommitIdPluginIntegrationTest.java
@@ -1584,6 +1584,35 @@ public class GitCommitIdPluginIntegrationTest {
   }
 
   @Test
+  @Parameters(method = "useNativeGit")
+  public void shouldWorkWithRelativeSubmodules(boolean useNativeGit) throws Exception {
+    // given
+    File parentProjectDotGit =
+        createTmpDotGitDirectory(AvailableGitTestRepo.WITH_REMOTE_SUBMODULES);
+    File submoduleDotGitDirectory = parentProjectDotGit.getParentFile().toPath().resolve(
+        "remote-module").resolve(".git").toFile();
+    submoduleDotGitDirectory.getParentFile().mkdir();
+    Files.write(
+        submoduleDotGitDirectory.toPath(),
+        "gitdir: ../.git/modules/remote-module".getBytes()
+    );
+
+
+    GitCommitIdPlugin.Callback cb =
+        new GitCommitIdTestCallback()
+        .setDotGitDirectory(submoduleDotGitDirectory)
+        .setUseNativeGit(useNativeGit)
+        .build();
+    Properties properties = new Properties();
+
+    // when
+    GitCommitIdPlugin.runPlugin(cb, properties);
+
+    // then
+    assertPropertyPresentAndEqual(properties, "git.commit.id.abbrev", "945bfe6");
+  }
+
+  @Test
   public void verifyAllowedCharactersForEvaluateOnCommit() {
     Pattern p = GitCommitIdPlugin.allowedCharactersForEvaluateOnCommit;
     assertTrue(p.matcher("5957e419d").matches());

--- a/src/test/java/pl/project13/core/GitCommitIdPluginIntegrationTest.java
+++ b/src/test/java/pl/project13/core/GitCommitIdPluginIntegrationTest.java
@@ -414,6 +414,7 @@ public class GitCommitIdPluginIntegrationTest {
             new GitCommitIdTestCallback()
                     .setDotGitDirectory(emptyGitDir)
                     .setUseNativeGit(useNativeGit)
+                    .setShouldFailOnNoGitDirectory(true)
                     .build();
     Properties properties = new Properties();
 

--- a/src/test/java/pl/project13/core/GitCommitIdTestCallback.java
+++ b/src/test/java/pl/project13/core/GitCommitIdTestCallback.java
@@ -57,6 +57,7 @@ public class GitCommitIdTestCallback {
   private File generateGitPropertiesFilename;
   private Charset propertiesSourceCharset = StandardCharsets.UTF_8;
   private boolean shouldPropertiesEscapeUnicode = false;
+  private boolean shouldFailOnNoGitDirectory = false;
 
   public GitCommitIdTestCallback() {
     try {
@@ -190,6 +191,11 @@ public class GitCommitIdTestCallback {
 
   public GitCommitIdTestCallback setShouldPropertiesEscapeUnicode(boolean shouldPropertiesEscapeUnicode) {
     this.shouldPropertiesEscapeUnicode = shouldPropertiesEscapeUnicode;
+    return this;
+  }
+
+  public GitCommitIdTestCallback setShouldFailOnNoGitDirectory(boolean shouldFailOnNoGitDirectory) {
+    this.shouldFailOnNoGitDirectory = shouldFailOnNoGitDirectory;
     return this;
   }
 
@@ -340,6 +346,11 @@ public class GitCommitIdTestCallback {
       @Override
       public boolean shouldPropertiesEscapeUnicode() {
         return shouldPropertiesEscapeUnicode;
+      }
+
+      @Override
+      public boolean shouldFailOnNoGitDirectory() {
+        return shouldFailOnNoGitDirectory;
       }
     };
   }

--- a/src/test/java/pl/project13/core/util/GitDirLocatorTest.java
+++ b/src/test/java/pl/project13/core/util/GitDirLocatorTest.java
@@ -1,0 +1,119 @@
+/*
+ * This file is part of git-commit-id-plugin-core by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ *
+ * git-commit-id-plugin-core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * git-commit-id-plugin-core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with git-commit-id-plugin-core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pl.project13.core.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.file.Files;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GitDirLocatorTest {
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  @Test
+  public void shouldUseTheManuallySpecifiedDirectory() throws Exception {
+    // given
+    File dotGitDir = folder.newFolder("temp");
+    try {
+      // when
+      GitDirLocator locator = new GitDirLocator(dotGitDir);
+      File foundDirectory = locator.lookupGitDirectory(dotGitDir);
+
+      // then
+      assertThat(foundDirectory).isNotNull();
+      assertThat(foundDirectory.getAbsolutePath()).isEqualTo(dotGitDir.getAbsolutePath());
+    } finally {
+      if (!dotGitDir.delete()) {
+        dotGitDir.deleteOnExit();
+      }
+    }
+  }
+
+  @Test
+  public void shouldResolveRelativeSubmodule() throws Exception {
+    // given
+    folder.newFolder("main-project");
+    folder.newFolder("main-project", ".git", "modules", "sub-module");
+    folder.newFolder("main-project", "sub-module");
+
+    // and a .git dir in submodule that points to the main's project .git/modules/submodule
+    File dotGitDir = folder.getRoot().toPath()
+        .resolve("main-project")
+        .resolve("sub-module")
+        .resolve(".git")
+        .toFile();
+    Files.write(
+        dotGitDir.toPath(),
+        "gitdir: ../.git/modules/sub-module".getBytes()
+    );
+
+    try {
+      // when
+      GitDirLocator locator = new GitDirLocator(dotGitDir);
+      File foundDirectory = locator.lookupGitDirectory(dotGitDir);
+
+      // then
+      assertThat(foundDirectory).isNotNull();
+      assertThat(
+          foundDirectory.getCanonicalFile()
+      ).isEqualTo(
+          folder.getRoot().toPath()
+          .resolve("main-project")
+          .resolve(".git")
+          .resolve("modules")
+          .resolve("sub-module")
+          .toFile()
+      );
+    } finally {
+      if (!dotGitDir.delete()) {
+        dotGitDir.deleteOnExit();
+      }
+    }
+  }
+
+  @Test
+  public void testWorktreeResolution() {
+    // tests to ensure we do not try to modify things that should not be modified
+    String[] noopCases = {
+      "",
+      "a",
+      "a/b",
+      ".git/worktrees",
+      ".git/worktrees/",
+      "a.git/worktrees/b",
+      ".git/modules",
+      ".git/modules/",
+      "a.git/modules/b",
+    };
+    for (String path : noopCases) {
+      assertThat(GitDirLocator.resolveWorktree(new File(path))).isEqualTo(new File(path));
+    }
+    // tests that worktree resolution works
+    assertThat(GitDirLocator.resolveWorktree(new File("a/.git/worktrees/b")))
+        .isEqualTo(new File("a/.git"));
+    assertThat(GitDirLocator.resolveWorktree(new File("/a/.git/worktrees/b")))
+        .isEqualTo(new File("/a/.git"));
+  }
+}

--- a/src/test/java/pl/project13/core/util/GitDirLocatorTest.java
+++ b/src/test/java/pl/project13/core/util/GitDirLocatorTest.java
@@ -38,7 +38,7 @@ public class GitDirLocatorTest {
     File dotGitDir = folder.newFolder("temp");
     try {
       // when
-      GitDirLocator locator = new GitDirLocator(dotGitDir);
+      GitDirLocator locator = new GitDirLocator(dotGitDir, true);
       File foundDirectory = locator.lookupGitDirectory(dotGitDir);
 
       // then
@@ -71,7 +71,7 @@ public class GitDirLocatorTest {
 
     try {
       // when
-      GitDirLocator locator = new GitDirLocator(dotGitDir);
+      GitDirLocator locator = new GitDirLocator(dotGitDir, true);
       File foundDirectory = locator.lookupGitDirectory(dotGitDir);
 
       // then

--- a/src/test/java/pl/project13/core/util/GitDirLocatorTest.java
+++ b/src/test/java/pl/project13/core/util/GitDirLocatorTest.java
@@ -38,7 +38,7 @@ public class GitDirLocatorTest {
     File dotGitDir = folder.newFolder("temp");
     try {
       // when
-      GitDirLocator locator = new GitDirLocator(dotGitDir, true);
+      GitDirLocator locator = new GitDirLocator(dotGitDir, false, true);
       File foundDirectory = locator.lookupGitDirectory(dotGitDir);
 
       // then
@@ -71,7 +71,7 @@ public class GitDirLocatorTest {
 
     try {
       // when
-      GitDirLocator locator = new GitDirLocator(dotGitDir, true);
+      GitDirLocator locator = new GitDirLocator(dotGitDir, false, true);
       File foundDirectory = locator.lookupGitDirectory(dotGitDir);
 
       // then


### PR DESCRIPTION
### Context
This MR fixes an issue with submodules (see https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/701)

Needed changes:
- move the GitDirLocator from `git-commit-id-maven-plugin` to `git-commit-id-plugin-core`
- extended the `Callback` with `shouldFailOnNoGitDirectory` that determines if the execution should fail if no git directory can be extracted (please note that build information might now be populated since it is unrelated to git data)


### Contributor Checklist
- [X] Added relevant integration or unit tests to verify the changes
- [X] Update the Readme or any other documentation (including relevant Javadoc)
- [X] Ensured that tests pass locally: `mvn clean package`
- [X] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
