### PR TITLE
#99: try to improve error messages when the json properties can't be read

### DIFF
--- a/src/main/java/pl/project13/core/util/GenericFileManager.java
+++ b/src/main/java/pl/project13/core/util/GenericFileManager.java
@@ -33,7 +33,10 @@ import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Properties;
+import java.util.Set;
 
 public class GenericFileManager {
   public static Properties readPropertiesAsUtf8(
@@ -61,6 +64,7 @@ public class GenericFileManager {
     );
   }
 
+  @Nonnull
   public static Properties readProperties(
       @Nullable LogInterface log,
       @Nonnull CommitIdPropertiesOutputFormat propertiesOutputFormat,
@@ -139,7 +143,9 @@ public class GenericFileManager {
         }
       }
     } catch (final IOException ex) {
-      throw new GitCommitIdExecutionException("Cannot create custom git properties file: " + gitPropsFile, ex);
+      throw new GitCommitIdExecutionException(
+        String.format("Failed to write %s file [%s] (for project %s)...",
+          propertiesOutputFormat.name().toLowerCase(), gitPropsFile.getAbsolutePath(), projectName));
     }
   }
 }

--- a/src/main/java/pl/project13/core/util/JsonManager.java
+++ b/src/main/java/pl/project13/core/util/JsonManager.java
@@ -64,6 +64,9 @@ public class JsonManager {
           });
         }
       }
+    } catch (jakarta.json.stream.JsonParsingException e) {
+      // We are likely trying to read a properties that that was not encoded with json-syntax
+      throw new CannotReadFileException(e);
     } catch (IOException e) {
       throw new CannotReadFileException(e);
     }

--- a/src/main/java/pl/project13/core/util/YmlManager.java
+++ b/src/main/java/pl/project13/core/util/YmlManager.java
@@ -67,10 +67,13 @@ public class YmlManager {
         loaderOptions.setProcessComments(false);
         Yaml yaml = new Yaml(loaderOptions);
         Map<String, Object> data = yaml.load(reader);
-        for (Map.Entry<String, Object> e: data.entrySet()) {
+        for (Map.Entry<String, Object> e : data.entrySet()) {
           retVal.put(e.getKey(), e.getValue());
         }
       }
+    } catch (ClassCastException e) {
+      // We are likely trying to read a properties that that was not encoded with yml-syntax
+      throw new CannotReadFileException(e);
     } catch (IOException e) {
       throw new CannotReadFileException(e);
     }


### PR DESCRIPTION
https://github.com/git-commit-id/git-commit-id-plugin-core/issues/99
### Context
<!--- Thank you for your contribution to this project! :-) -->
<!--- Please tell us a bit more what do you indent with your change and how users of the plugin will benefit from it. -->
<!--- If applicable also provide a link to any relevant issue. -->

### Contributor Checklist
- [ ] Added relevant integration or unit tests to verify the changes
- [ ] Update the Readme or any other documentation (including relevant Javadoc)
- [ ] Ensured that tests pass locally: `mvn clean package`
- [ ] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
