### PR TITLE
Added support for build number in Github Actions

### DIFF
--- a/src/main/java/pl/project13/core/GitCommitPropertyConstant.java
+++ b/src/main/java/pl/project13/core/GitCommitPropertyConstant.java
@@ -108,14 +108,15 @@ public class GitCommitPropertyConstant {
    *
    * Currently supported CIs:
    * <ul>
+   *   <li>AWS CodeBuild</li>
+   *   <li>Azure DevOps</li>
    *   <li>Bamboo</li>
+   *   <li>Bitbucket Pipelines</li>
+   *   <li>GitHub Actions</li>
+   *   <li>Gitlab CI (Gitlab &gt;8.10 &amp; Gitlab CI &gt;0.5)</li>
    *   <li>Hudson/Jenkins</li>
    *   <li>TeamCity</li>
    *   <li>Travis</li>
-   *   <li>Gitlab CI (Gitlab &gt;8.10 &amp; Gitlab CI &gt;0.5)</li>
-   *   <li>Azure DevOps</li>
-   *   <li>AWS CodeBuild</li>
-   *   <li>Bitbucket Pipelines</li>
    * </ul>
    */
   public static final String BUILD_NUMBER = "build.number";
@@ -127,10 +128,11 @@ public class GitCommitPropertyConstant {
    *
    * Currently supported CIs:
    * <ul>
-   *     <li>TeamCity</li>
-   *     <li>Travis</li>
-   *     <li>Gitlab CI (Gitlab &gt;11.0)</li>
-   *     <li>AWS CodeBuild</li>
+   *   <li>AWS CodeBuild</li>
+   *   <li>Gitlab CI (Gitlab &gt;11.0)</li>
+   *   <li>GitHub Actions</li>
+   *   <li>TeamCity</li>
+   *   <li>Travis</li>
    * </ul>
    */
   public static final String BUILD_NUMBER_UNIQUE = "build.number.unique";

--- a/src/main/java/pl/project13/core/cibuild/GitHubBuildServerData.java
+++ b/src/main/java/pl/project13/core/cibuild/GitHubBuildServerData.java
@@ -17,6 +17,7 @@
 
 package pl.project13.core.cibuild;
 
+import pl.project13.core.GitCommitPropertyConstant;
 import pl.project13.core.log.LogInterface;
 
 import javax.annotation.Nonnull;
@@ -39,7 +40,9 @@ public class GitHubBuildServerData extends BuildServerDataProvider {
 
   @Override
   void loadBuildNumber(@Nonnull Properties properties) {
-    // This information is not reliably available on GitHub Actions
+    String buildNumber = env.getOrDefault("GITHUB_RUN_NUMBER", "");
+
+    maybePut(properties, GitCommitPropertyConstant.BUILD_NUMBER, () -> buildNumber);
   }
 
   @Override

--- a/src/main/java/pl/project13/core/cibuild/GitHubBuildServerData.java
+++ b/src/main/java/pl/project13/core/cibuild/GitHubBuildServerData.java
@@ -40,9 +40,12 @@ public class GitHubBuildServerData extends BuildServerDataProvider {
 
   @Override
   void loadBuildNumber(@Nonnull Properties properties) {
-    String buildNumber = env.getOrDefault("GITHUB_RUN_NUMBER", "");
+    String runId = env.getOrDefault("GITHUB_RUN_ID", "0");
+    String runNumber = env.getOrDefault("GITHUB_RUN_NUMBER", "0");
+    String runAttempt = env.getOrDefault("GITHUB_RUN_ATTEMPT", "0");
 
-    maybePut(properties, GitCommitPropertyConstant.BUILD_NUMBER, () -> buildNumber);
+    maybePut(properties, GitCommitPropertyConstant.BUILD_NUMBER, () -> String.join(".", runNumber, runAttempt));
+    maybePut(properties, GitCommitPropertyConstant.BUILD_NUMBER_UNIQUE, () -> String.join(".", runId, runNumber, runAttempt));
   }
 
   @Override

--- a/src/test/java/pl/project13/core/GitCommitIdTestCallback.java
+++ b/src/test/java/pl/project13/core/GitCommitIdTestCallback.java
@@ -18,6 +18,7 @@
 package pl.project13.core;
 
 import pl.project13.core.git.GitDescribeConfig;
+import pl.project13.core.log.DummyLogInterface;
 import pl.project13.core.log.LogInterface;
 import pl.project13.core.util.BuildFileChangeListener;
 
@@ -34,7 +35,7 @@ import java.util.function.Supplier;
 public class GitCommitIdTestCallback {
   private Map<String, String> systemEnv = System.getenv();
   private String projectVersion = "dummy-version";
-  private LogInterface logInterface = createDummyLogInterface();
+  private LogInterface logInterface = new DummyLogInterface();
   private String dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ";
   private String dateFormatTimeZone = TimeZone.getDefault().getID();
   private String prefixDot = "git.";
@@ -361,34 +362,5 @@ public class GitCommitIdTestCallback {
     gitDescribeConfig.setForceLongFormat(forceLongFormat);
     gitDescribeConfig.setAbbrev(abbrev);
     return gitDescribeConfig;
-  }
-
-  private LogInterface createDummyLogInterface() {
-    return new LogInterface() {
-      @Override
-      public void debug(String msg) {
-        // ignore
-      }
-
-      @Override
-      public void info(String msg) {
-        // ignore
-      }
-
-      @Override
-      public void warn(String msg) {
-        // ignore
-      }
-
-      @Override
-      public void error(String msg) {
-        // ignore
-      }
-
-      @Override
-      public void error(String msg, Throwable t) {
-        // ignore
-      }
-    };
   }
 }

--- a/src/test/java/pl/project13/core/cibuild/BuildServerDataProviderTest.java
+++ b/src/test/java/pl/project13/core/cibuild/BuildServerDataProviderTest.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of git-commit-id-plugin-core by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ *
+ * git-commit-id-plugin-core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * git-commit-id-plugin-core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with git-commit-id-plugin-core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package pl.project13.core.cibuild;
 
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/pl/project13/core/cibuild/BuildServerDataProviderTest.java
+++ b/src/test/java/pl/project13/core/cibuild/BuildServerDataProviderTest.java
@@ -49,23 +49,28 @@ class BuildServerDataProviderTest {
     @Test
     void shouldLoadBuildNumber() {
       Properties properties = new Properties();
-      Map<String, String> environment = Map.of("GITHUB_RUN_NUMBER", "123");
+      Map<String, String> environment = Map.of(
+          "GITHUB_RUN_ID", "1658821493",
+          "GITHUB_RUN_NUMBER", "123",
+          "GITHUB_RUN_ATTEMPT", "1");
       GitHubBuildServerData provider = new GitHubBuildServerData(new DummyLogInterface(), environment);
 
       provider.loadBuildNumber(properties);
 
-      assertThat(properties).containsEntry(GitCommitPropertyConstant.BUILD_NUMBER, "123");
+      assertThat(properties).containsEntry(GitCommitPropertyConstant.BUILD_NUMBER, "123.1");
+      assertThat(properties).containsEntry(GitCommitPropertyConstant.BUILD_NUMBER_UNIQUE, "1658821493.123.1");
     }
 
     @Test
-    void shouldLoadBuildNumberAsEmptyIfNotAvailable() {
+    void shouldLoadBuildNumberAsZerosIfNotAvailable() {
       Properties properties = new Properties();
       Map<String, String> environment = Map.of();
       GitHubBuildServerData provider = new GitHubBuildServerData(new DummyLogInterface(), environment);
 
       provider.loadBuildNumber(properties);
 
-      assertThat(properties).containsEntry(GitCommitPropertyConstant.BUILD_NUMBER, "");
+      assertThat(properties).containsEntry(GitCommitPropertyConstant.BUILD_NUMBER, "0.0");
+      assertThat(properties).containsEntry(GitCommitPropertyConstant.BUILD_NUMBER_UNIQUE, "0.0.0");
     }
 
     @Test

--- a/src/test/java/pl/project13/core/cibuild/BuildServerDataProviderTest.java
+++ b/src/test/java/pl/project13/core/cibuild/BuildServerDataProviderTest.java
@@ -1,0 +1,79 @@
+package pl.project13.core.cibuild;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import pl.project13.core.GitCommitPropertyConstant;
+import pl.project13.core.log.DummyLogInterface;
+
+import java.util.Map;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BuildServerDataProviderTest {
+  @Test
+  void shouldSelectGithubAsDataProvider() {
+    Map<String, String> environment = Map.of("GITHUB_ACTIONS", "true");
+
+    BuildServerDataProvider provider = BuildServerDataProvider.getBuildServerProvider(environment, new DummyLogInterface());
+
+    assertThat(provider).isInstanceOf(GitHubBuildServerData.class);
+  }
+
+  @Nested
+  class GithubProviderTests {
+    @Test
+    void shouldVerifyOnGithubEnvironment() {
+      Map<String, String> environment = Map.of("GITHUB_ACTIONS", "true");
+
+      assertThat(GitHubBuildServerData.isActiveServer(environment)).isTrue();
+    }
+
+    @Test
+    void shouldLoadBuildNumber() {
+      Properties properties = new Properties();
+      Map<String, String> environment = Map.of("GITHUB_RUN_NUMBER", "123");
+      GitHubBuildServerData provider = new GitHubBuildServerData(new DummyLogInterface(), environment);
+
+      provider.loadBuildNumber(properties);
+
+      assertThat(properties).containsEntry(GitCommitPropertyConstant.BUILD_NUMBER, "123");
+    }
+
+    @Test
+    void shouldLoadBuildNumberAsEmptyIfNotAvailable() {
+      Properties properties = new Properties();
+      Map<String, String> environment = Map.of();
+      GitHubBuildServerData provider = new GitHubBuildServerData(new DummyLogInterface(), environment);
+
+      provider.loadBuildNumber(properties);
+
+      assertThat(properties).containsEntry(GitCommitPropertyConstant.BUILD_NUMBER, "");
+    }
+
+    @Test
+    void shouldLoadBranchNameForPullRequestBuild() {
+      Map<String, String> environment = Map.of("GITHUB_REF", "refs/pull/feature_branch",
+          "GITHUB_HEAD_REF", "feature_branch");
+      GitHubBuildServerData provider = new GitHubBuildServerData(new DummyLogInterface(), environment);
+
+      assertThat(provider.getBuildBranch()).isEqualTo("feature_branch");
+    }
+
+    @Test
+    void shouldLoadBranchNameForBranchBuild() {
+      Map<String, String> environment = Map.of("GITHUB_REF", "refs/heads/feature_branch");
+      GitHubBuildServerData provider = new GitHubBuildServerData(new DummyLogInterface(), environment);
+
+      assertThat(provider.getBuildBranch()).isEqualTo("feature_branch");
+    }
+
+    @Test
+    void shouldLoadBranchNameAsEmptyIfNotAvailable() {
+      Map<String, String> environment = Map.of();
+      GitHubBuildServerData provider = new GitHubBuildServerData(new DummyLogInterface(), environment);
+
+      assertThat(provider.getBuildBranch()).isEmpty();
+    }
+  }
+}

--- a/src/test/java/pl/project13/core/log/DummyLogInterface.java
+++ b/src/test/java/pl/project13/core/log/DummyLogInterface.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of git-commit-id-plugin-core by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ *
+ * git-commit-id-plugin-core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * git-commit-id-plugin-core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with git-commit-id-plugin-core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package pl.project13.core.log;
 
 public class DummyLogInterface implements LogInterface {

--- a/src/test/java/pl/project13/core/log/DummyLogInterface.java
+++ b/src/test/java/pl/project13/core/log/DummyLogInterface.java
@@ -1,0 +1,28 @@
+package pl.project13.core.log;
+
+public class DummyLogInterface implements LogInterface {
+  @Override
+  public void debug(String msg) {
+    // ignore
+  }
+
+  @Override
+  public void info(String msg) {
+    // ignore
+  }
+
+  @Override
+  public void warn(String msg) {
+    // ignore
+  }
+
+  @Override
+  public void error(String msg) {
+    // ignore
+  }
+
+  @Override
+  public void error(String msg, Throwable t) {
+    // ignore
+  }
+}


### PR DESCRIPTION
### Context
Added support for determining the build number on Github Actions. Apparently it was not that easy task when the initial support was added.

### Contributor Checklist
- [x] Added relevant integration or unit tests to verify the changes
- [x] Update the Readme or any other documentation (including relevant Javadoc)
- [x] Ensured that tests pass locally: `mvn clean package`
- [x] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`