### PR TITLE
Update pom.xml to migrate to org.eclipse.jgit.ssh.apache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,8 +215,13 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
-            <artifactId>org.eclipse.jgit.ssh.jsch</artifactId>
+            <artifactId>org.eclipse.jgit.ssh.apache</artifactId>
             <version>${jgit.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>1.81</version>
         </dependency>
         <!-- Joda Time -->
         <dependency>


### PR DESCRIPTION
Migrating to org.eclipse.jgit.ssh.apache, I am able to auth to git using id_ed25519 as a private key.

### Context
<!--- Thank you for your contribution to this project! :-) -->
<!--- Please tell us a bit more what do you indent with your change and how users of the plugin will benefit from it. -->
<!--- If applicable also provide a link to any relevant issue. -->

### Contributor Checklist
- [ ] Added relevant integration or unit tests to verify the changes
- [ ] Update the Readme or any other documentation (including relevant Javadoc)
- [ ] Ensured that tests pass locally: `mvn clean package`
- [ ] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
