### PR TITLE
chore: Bump org.bouncycastle:bcprov-jdk18on 1.84 -> 1.85 for CVE-2026-59638.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
-            <version>1.84</version>
+            <version>1.85</version>
         </dependency>
         <dependency>
             <groupId>org.jspecify</groupId>


### PR DESCRIPTION
[https://www.cve.org/CVERecord\?id\=CVE-2026-59638](https://www.cve.org/CVERecord?id=CVE-2026-59638)

### Contributor Checklist
- [ ] Added relevant integration or unit tests to verify the changes
- [ ] Update the Readme or any other documentation (including relevant Javadoc)
- [x] Ensured that tests pass locally: `mvn clean package` 
- [x] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
